### PR TITLE
feat: scaffold portfolio site

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['next', 'next/core-web-vitals', 'prettier'],
+  rules: {}
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm build

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,19 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+node_modules
+.next
+out
+.env
+.env.local
+.DS_Store
+pnpm-lock.yaml
+npm-debug.log*
+
+# Logs
+logs
+*.log
+
+# Testing
+coverage
+
+# Editor directories
+.idea
+.vscode
+
+# Ignore sample media assets to keep repository text-only
+public/media/**/*.{png,jpg,jpeg,gif}
+docs/screenshots/**/*.{png,jpg,jpeg,gif}

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ -z "$husky_skip_init" ]; then
+  husky_skip_init=1 . "$0" "$@"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "singleQuote": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-01-01
+- Initial scaffolding of Next.js portfolio project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thanks for your interest in contributing! Please follow these guidelines:
+
+- Fork the repo and create a new branch for your feature or fix.
+- Run `pnpm lint` and `pnpm test` before submitting a PR.
+- Add tests for any new features.
+- Update documentation when necessary.
+
+We follow the [Contributor Covenant](https://www.contributor-covenant.org/).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* ./
+RUN npm install -g pnpm && pnpm install
+COPY . .
+RUN pnpm build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app .
+EXPOSE 3000
+CMD ["pnpm", "start"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Melli Tiara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,93 +1,24 @@
-<h1 align="center">Hey, I'm Melli 👋</h1>
-<p align="center">
-  💻 Software Engineer • 🧠 AI Learner • 🌐 Web3 Enthusiast • ✈️ Remote Dreamer
-</p>
+# Melli Portfolio
 
-<p align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&duration=2500&pause=1000&center=true&vCenter=true&width=435&lines=Engineer+with+a+backend+soul;Breaking+tech+limits+with+Golang+%26+Python;Building+AI+%2B+Web3+automation+like+a+wizard" alt="Typing SVG" />
-</p>
+A JSON-driven developer portfolio with a GitHub-inspired aesthetic. Built with Next.js, React, and Tailwind CSS.
 
----
+## Getting Started
 
-### 🚀 About Me
+```bash
+pnpm install
+pnpm dev
+```
 
-Hi, I’m Melli — a curious & passionate software engineer with 5+ years of experience in backend engineering.  
-I'm on a journey to master AI & Web3 while building systems that scale and spark ✨.
+## Content
 
-I'm a builder at heart: from **multi-server VPN managers** to **auto-reposting AI engines for social media monetization** — I craft things that *just work* but also *look cool doing it*.
+All content lives in `content/data.json` and related MDX/Markdown files.
 
-- 🔭 Currently building: Repost Engine (TikTok + IG auto-content system) & VPN Provisioning Platform
-- 🧠 Learning daily: AI agents, vector DB, LangChain, autonomous workflow orchestration
-- 🌎 Working towards: full remote freedom & global tech collabs
-- 🎥 Side hobbies: photography, exploring outdoors, and getting lost in mountains & savannahs
+## Docker
 
----
+```bash
+docker compose up --build
+```
 
-### 🛠️ Tech Stack
+## License
 
-#### Backend
-![Golang](https://img.shields.io/badge/Golang-00ADD8?logo=go&logoColor=white)
-![Python](https://img.shields.io/badge/Python-3670A0?logo=python&logoColor=white)
-![Node.js](https://img.shields.io/badge/Node.js-339933?logo=nodedotjs&logoColor=white)
-![Redis](https://img.shields.io/badge/Redis-DC382D?logo=redis&logoColor=white)
-![Kafka](https://img.shields.io/badge/Kafka-231F20?logo=apachekafka&logoColor=white)
-
-#### Web3 & Blockchain
-![Solidity](https://img.shields.io/badge/Solidity-363636?logo=solidity&logoColor=white)
-![Ethereum](https://img.shields.io/badge/Ethereum-3C3C3D?logo=ethereum&logoColor=white)
-![Metamask](https://img.shields.io/badge/Metamask-F6851B?logo=metamask&logoColor=white)
-
-#### AI & Tools
-![LangChain](https://img.shields.io/badge/LangChain-000000?logo=LangChain&logoColor=white)
-![OpenAI](https://img.shields.io/badge/OpenAI-412991?logo=openai&logoColor=white)
-![Flowise](https://img.shields.io/badge/Flowise-EFF2F6?logo=data&logoColor=black)
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=white)
-
----
-
-### 🧩 Current Projects
-
-| Project | Description | Stack |
-|--------|-------------|--------|
-| **Repost Engine** | AI-driven automation system for scraping, editing, voiceover, and posting viral content to TikTok/IG | Python, ffmpeg, GPT, IG API |
-| **VPN Manager** | Centralized VPN provisioning backend & remote agent via WireGuard | Golang, gRPC, Redis |
-| **Cloaking CMS** | Laravel + Livewire dashboard to manage cloaked domains, traffic filtering, and logs at scale | Laravel, Go API, MySQL |
-| **Stock Bot Indo** | Daily pre-market stock analyzer for potential ARA using orderbook & sentiment data | Python, IDX, Telegram Bot |
-
----
-
-### 📈 GitHub Stats
-
-<p align="center">
-  <img src="https://github-readme-stats.vercel.app/api?username=melli-dev&show_icons=true&theme=radical&hide_rank=false" />
-</p>
-
-<p align="center">
-  <img src="https://github-readme-streak-stats.herokuapp.com/?user=melli-dev&theme=radical" />
-</p>
-
----
-
-### 🧭 Let’s Connect
-
-- 🌐 [Portfolio Website](https://yourdomain.dev)
-- 💼 [LinkedIn](https://linkedin.com/in/yourlinkedin)
-- 📸 [Instagram](https://instagram.com/yourig)
-- ✉️ Reach me: your@email.com
-
----
-
-<details>
-  <summary>🌈 Fun Facts About Me</summary>
-  <ul>
-    <li>I love the sky, open nature, and spontaneous conversations.</li>
-    <li>Sometimes I’m clingy, sometimes I’m coding until 3AM.</li>
-    <li>I believe in the power of ideas, and I love sharing weird, fun, or profound thoughts.</li>
-  </ul>
-</details>
-
----
-
-<p align="center">
-  <i>“Make it smart. Make it useful. Make it emotionally resonant.”</i>
-</p>
+MIT

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+
+export default function AboutPage() {
+  const file = fs.readFileSync(path.join(process.cwd(), 'content/about.md'), 'utf-8');
+  return (
+    <article className="p-4 prose prose-invert">
+      <MDXRemote source={file} />
+    </article>
+  );
+}

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const data = await req.formData();
+  // Placeholder handler
+  return NextResponse.json({ ok: true, email: data.get('email') });
+}

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  return NextResponse.json({ revalidated: true });
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from 'next/navigation';
+import data from '../../../content/data.json';
+import fs from 'fs';
+import path from 'path';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+
+export default async function BlogPost({ params }: { params: { slug: string } }) {
+  const post = data.blog.find((p) => p.slug === params.slug);
+  if (!post) return notFound();
+  const file = fs.readFileSync(path.join(process.cwd(), 'content', post.mdx), 'utf-8');
+  return (
+    <article className="p-4">
+      <h1 className="text-3xl font-bold">{post.title}</h1>
+      <MDXRemote source={file} />
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import data from '../../content/data.json';
+
+export default function BlogPage() {
+  return (
+    <div className="p-4 space-y-4">
+      {data.blog.map((post) => (
+        <Link key={post.slug} href={`/blog/${post.slug}`} className="block p-4 bg-gray-800 rounded">
+          <h3 className="text-lg font-semibold">{post.title}</h3>
+          <p className="text-sm text-gray-400">{post.excerpt}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useState } from 'react';
+
+export default function ContactPage() {
+  const [sent, setSent] = useState(false);
+  async function submit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    await fetch('/api/contact', { method: 'POST', body: formData });
+    setSent(true);
+  }
+  return (
+    <div className="p-4">
+      {sent ? (
+        <p>Thanks!</p>
+      ) : (
+        <form onSubmit={submit} className="flex flex-col gap-2 max-w-md">
+          <input name="email" type="email" required placeholder="Email" className="p-2 rounded bg-gray-800" />
+          <textarea name="message" required placeholder="Message" className="p-2 rounded bg-gray-800" />
+          <button className="p-2 bg-blue-600 rounded" type="submit">Send</button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/app/experience/page.tsx
+++ b/app/experience/page.tsx
@@ -1,0 +1,19 @@
+import data from '../../content/data.json';
+
+export default function ExperiencePage() {
+  return (
+    <div className="p-4 space-y-6">
+      {data.experiences.map((exp) => (
+        <div key={exp.company} className="bg-gray-800 p-4 rounded">
+          <h3 className="text-lg font-semibold">{exp.role} @ {exp.company}</h3>
+          <p className="text-sm text-gray-400">{exp.start} – {exp.end ?? 'Present'}</p>
+          <ul className="list-disc ml-4 mt-2 text-sm">
+            {exp.highlights.map((h) => (
+              <li key={h}>{h}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import ThemeToggle from '../components/ThemeToggle';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="dark">
+      <body className="min-h-screen bg-gray-900 text-gray-100">
+        <header className="p-4 flex justify-end">
+          <ThemeToggle />
+        </header>
+        <main className="flex">
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,27 @@
+import ProfileSidebar from '../components/ProfileSidebar';
+import PinnedProjectCard from '../components/PinnedProjectCard';
+import Heatmap from '../components/Heatmap';
+import data from '../content/data.json';
+
+export default function HomePage() {
+  const pinned = data.projects.filter((p) => p.pinned);
+  return (
+    <div className="flex w-full">
+      <ProfileSidebar />
+      <div className="flex-1 p-4 space-y-8">
+        <section>
+          <h2 className="text-2xl font-bold">Pinned Projects</h2>
+          <div className="grid md:grid-cols-2 gap-4 mt-4">
+            {pinned.map((p) => (
+              <PinnedProjectCard key={p.slug} project={p} />
+            ))}
+          </div>
+        </section>
+        <section>
+          <h2 className="text-2xl font-bold">Contributions</h2>
+          <Heatmap data={data.contributions.heatmap} />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from 'next/navigation';
+import data from '../../../content/data.json';
+import fs from 'fs';
+import path from 'path';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import Callout from '../../../components/Callout';
+
+export default async function ProjectDetail({ params }: { params: { slug: string } }) {
+  const project = data.projects.find((p) => p.slug === params.slug);
+  if (!project) return notFound();
+  const file = fs.readFileSync(path.join(process.cwd(), 'content', project.case_study_mdx), 'utf-8');
+  return (
+    <article className="p-4">
+      <h1 className="text-3xl font-bold">{project.name}</h1>
+      <MDXRemote source={file} components={{ Callout }} />
+    </article>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import data from '../../content/data.json';
+
+export default function ProjectsPage() {
+  return (
+    <div className="p-4 space-y-4">
+      {data.projects.map((p) => (
+        <Link key={p.slug} href={`/projects/${p.slug}`} className="block p-4 bg-gray-800 rounded">
+          <h3 className="text-lg font-semibold">{p.name}</h3>
+          <p className="text-sm text-gray-400">{p.summary}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/Callout.tsx
+++ b/components/Callout.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  type?: 'info' | 'success' | 'error';
+  children: ReactNode;
+}
+
+const colors: Record<string, string> = {
+  info: 'border-blue-500',
+  success: 'border-green-500',
+  error: 'border-red-500'
+};
+
+export default function Callout({ title, type = 'info', children }: Props) {
+  return (
+    <div className={`border-l-4 p-4 my-4 ${colors[type]}`}>
+      <strong>{title}</strong>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -1,0 +1,22 @@
+interface Day {
+  date: string;
+  count: number;
+}
+
+interface Props {
+  data: Day[];
+}
+
+export default function Heatmap({ data }: Props) {
+  return (
+    <div className="grid grid-cols-7 gap-1">
+      {data.map((d) => (
+        <div
+          key={d.date}
+          title={`${d.date}: ${d.count}`}
+          className={`w-3 h-3 rounded-sm bg-emerald-${Math.min(d.count, 4) * 200}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/PinnedProjectCard.tsx
+++ b/components/PinnedProjectCard.tsx
@@ -1,0 +1,19 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { Project } from '../lib/types';
+
+interface Props {
+  project: Project;
+}
+
+export default function PinnedProjectCard({ project }: Props) {
+  return (
+    <Link href={`/projects/${project.slug}`} className="block bg-gray-800 rounded-lg overflow-hidden">
+      <Image src={project.cover} alt={project.name} width={600} height={300} />
+      <div className="p-4">
+        <h3 className="text-lg font-semibold">{project.name}</h3>
+        <p className="text-sm text-gray-400">{project.summary}</p>
+      </div>
+    </Link>
+  );
+}

--- a/components/ProfileSidebar.tsx
+++ b/components/ProfileSidebar.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import data from '../content/data.json';
+
+export default function ProfileSidebar() {
+  const { profile, stats } = data;
+  return (
+    <aside className="p-4 bg-gray-800 rounded-xl w-full max-w-xs">
+      <Image
+        src={profile.avatar}
+        alt={profile.name}
+        width={80}
+        height={80}
+        className="rounded-full"
+      />
+      <h2 className="mt-2 text-xl font-semibold">{profile.name}</h2>
+      <p className="text-sm text-gray-400">{profile.headline}</p>
+      <ul className="mt-4 text-sm">
+        <li>Experience: {stats.years_experience} yrs</li>
+        <li>Projects: {stats.projects_shipped}</li>
+        <li>OSS contributions: {stats.oss_contributions}</li>
+      </ul>
+      <div className="flex gap-2 mt-4">
+        <Link href={`https://github.com/${profile.socials.github}`}>GitHub</Link>
+        <Link href={`https://linkedin.com/in/${profile.socials.linkedin}`}>LinkedIn</Link>
+      </div>
+    </aside>
+  );
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark);
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(!dark)} className="p-2">
+      {dark ? '🌙' : '☀️'}
+    </button>
+  );
+}

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,3 @@
+# About Me
+
+I love building scalable systems and exploring new technologies.

--- a/content/blog/scaling-ffmpeg.mdx
+++ b/content/blog/scaling-ffmpeg.mdx
@@ -1,0 +1,3 @@
+# Scaling FFmpeg Transcoding on Kubernetes
+
+Lessons learned from running HEVC/AV1 at scale.

--- a/content/data.example.json
+++ b/content/data.example.json
@@ -1,0 +1,75 @@
+{
+  "profile": {
+    "name": "Melli Tiara",
+    "headline": "Software Engineer — Backend, AI, Web3",
+    "location": "Jakarta, ID",
+    "avatar": "https://via.placeholder.com/150",
+    "bio_md": "./about.md",
+    "socials": {
+      "github": "melli",
+      "linkedin": "melli-tiara",
+      "x": "mellitiara",
+      "email": "hello@example.com"
+    }
+  },
+  "stats": {
+    "years_experience": 6,
+    "projects_shipped": 42,
+    "oss_contributions": 180
+  },
+  "skills": [
+    { "name": "Golang", "level": 9, "category": "backend" },
+    { "name": "Python", "level": 9, "category": "backend" },
+    { "name": "Kafka", "level": 7, "category": "infra" },
+    { "name": "Redis", "level": 8, "category": "infra" },
+    { "name": "Solidity", "level": 6, "category": "web3" }
+  ],
+  "experiences": [
+    {
+      "company": "Momentum Asia",
+      "role": "Senior Backend Engineer",
+      "start": "2023-04",
+      "end": null,
+      "location": "Remote",
+      "stack": ["Go", "Python", "Kafka", "Redis", "Postgres"],
+      "highlights": [
+        "Reduced transcoding costs by 28% via FFmpeg pipeline tuning",
+        "Designed VPN provisioning service handling 50k+ creds/month"
+      ]
+    }
+  ],
+  "projects": [
+    {
+      "slug": "vpn-orchestrator",
+      "name": "VPN Orchestrator",
+      "summary": "Centralized backend to provision WireGuard creds & audit logs",
+      "tags": ["Go", "WireGuard", "gRPC", "Kubernetes"],
+      "year": 2025,
+      "pinned": true,
+      "impact": { "users": 20000, "cost_savings_pct": 18 },
+      "cover": "https://via.placeholder.com/800x400",
+      "links": {
+        "repo": "https://github.com/...",
+        "demo": "https://demo.example.com"
+      },
+      "case_study_mdx": "./projects/vpn-orchestrator.mdx"
+    }
+  ],
+  "blog": [
+    {
+      "slug": "scaling-ffmpeg",
+      "title": "Scaling FFmpeg Transcoding on Kubernetes",
+      "date": "2025-07-18",
+      "tags": ["FFmpeg", "K8s", "Performance"],
+      "excerpt": "Lessons learned from running HEVC/AV1 at scale",
+      "mdx": "./blog/scaling-ffmpeg.mdx"
+    }
+  ],
+  "contributions": {
+    "year": 2025,
+    "heatmap": [
+      { "date": "2025-01-01", "count": 2 },
+      { "date": "2025-01-02", "count": 0 }
+    ]
+  }
+}

--- a/content/data.json
+++ b/content/data.json
@@ -1,0 +1,75 @@
+{
+  "profile": {
+    "name": "Melli Tiara",
+    "headline": "Software Engineer — Backend, AI, Web3",
+    "location": "Jakarta, ID",
+    "avatar": "https://via.placeholder.com/150",
+    "bio_md": "./about.md",
+    "socials": {
+      "github": "melli",
+      "linkedin": "melli-tiara",
+      "x": "mellitiara",
+      "email": "hello@example.com"
+    }
+  },
+  "stats": {
+    "years_experience": 6,
+    "projects_shipped": 42,
+    "oss_contributions": 180
+  },
+  "skills": [
+    { "name": "Golang", "level": 9, "category": "backend" },
+    { "name": "Python", "level": 9, "category": "backend" },
+    { "name": "Kafka", "level": 7, "category": "infra" },
+    { "name": "Redis", "level": 8, "category": "infra" },
+    { "name": "Solidity", "level": 6, "category": "web3" }
+  ],
+  "experiences": [
+    {
+      "company": "Momentum Asia",
+      "role": "Senior Backend Engineer",
+      "start": "2023-04",
+      "end": null,
+      "location": "Remote",
+      "stack": ["Go", "Python", "Kafka", "Redis", "Postgres"],
+      "highlights": [
+        "Reduced transcoding costs by 28% via FFmpeg pipeline tuning",
+        "Designed VPN provisioning service handling 50k+ creds/month"
+      ]
+    }
+  ],
+  "projects": [
+    {
+      "slug": "vpn-orchestrator",
+      "name": "VPN Orchestrator",
+      "summary": "Centralized backend to provision WireGuard creds & audit logs",
+      "tags": ["Go", "WireGuard", "gRPC", "Kubernetes"],
+      "year": 2025,
+      "pinned": true,
+      "impact": { "users": 20000, "cost_savings_pct": 18 },
+      "cover": "https://via.placeholder.com/800x400",
+      "links": {
+        "repo": "https://github.com/...",
+        "demo": "https://demo.example.com"
+      },
+      "case_study_mdx": "./projects/vpn-orchestrator.mdx"
+    }
+  ],
+  "blog": [
+    {
+      "slug": "scaling-ffmpeg",
+      "title": "Scaling FFmpeg Transcoding on Kubernetes",
+      "date": "2025-07-18",
+      "tags": ["FFmpeg", "K8s", "Performance"],
+      "excerpt": "Lessons learned from running HEVC/AV1 at scale",
+      "mdx": "./blog/scaling-ffmpeg.mdx"
+    }
+  ],
+  "contributions": {
+    "year": 2025,
+    "heatmap": [
+      { "date": "2025-01-01", "count": 2 },
+      { "date": "2025-01-02", "count": 0 }
+    ]
+  }
+}

--- a/content/projects/vpn-orchestrator.mdx
+++ b/content/projects/vpn-orchestrator.mdx
@@ -1,0 +1,15 @@
+import Callout from '../../components/Callout';
+
+# VPN Orchestrator
+
+<Callout title="Problem">
+Provisioning VPN credentials manually was error-prone and slow.
+</Callout>
+
+<Callout title="Approach" type="info">
+Built a gRPC service managing WireGuard peers and audit logs.
+</Callout>
+
+<Callout title="Impact" type="success">
+Handled 50k+ credentials per month with 18% cost savings.
+</Callout>

--- a/content/schema.json
+++ b/content/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "object",
+      "required": ["name", "headline"],
+      "properties": {
+        "name": {"type": "string"},
+        "headline": {"type": "string"}
+      }
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/app
+    command: pnpm dev

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+import { dataSchema, SiteData } from './zod';
+
+export function loadContent(): SiteData {
+  const file = fs.readFileSync(path.join(process.cwd(), 'content/data.json'), 'utf-8');
+  const json = JSON.parse(file);
+  const parsed = dataSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error('Invalid content: ' + parsed.error.message);
+  }
+  return parsed.data;
+}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,4 @@
+export const defaultMeta = {
+  title: 'Melli Tiara – Portfolio',
+  description: 'Personal portfolio site'
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,12 @@
+export interface Project {
+  slug: string;
+  name: string;
+  summary: string;
+  tags: string[];
+  year: number;
+  pinned: boolean;
+  impact: { users: number; cost_savings_pct: number };
+  cover: string;
+  links: { repo?: string; demo?: string };
+  case_study_mdx: string;
+}

--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+
+export const projectSchema = z.object({
+  slug: z.string(),
+  name: z.string(),
+  summary: z.string(),
+  tags: z.array(z.string()),
+  year: z.number(),
+  pinned: z.boolean(),
+  impact: z.object({
+    users: z.number(),
+    cost_savings_pct: z.number()
+  }),
+  cover: z.string(),
+  links: z.object({
+    repo: z.string().optional(),
+    demo: z.string().optional()
+  }),
+  case_study_mdx: z.string()
+});
+
+export const dataSchema = z.object({
+  profile: z.object({
+    name: z.string(),
+    headline: z.string(),
+    location: z.string(),
+    avatar: z.string(),
+    bio_md: z.string(),
+    socials: z.object({
+      github: z.string(),
+      linkedin: z.string(),
+      x: z.string(),
+      email: z.string()
+    })
+  }),
+  stats: z.object({
+    years_experience: z.number(),
+    projects_shipped: z.number(),
+    oss_contributions: z.number()
+  }),
+  skills: z.array(
+    z.object({ name: z.string(), level: z.number(), category: z.string() })
+  ),
+  experiences: z.array(
+    z.object({
+      company: z.string(),
+      role: z.string(),
+      start: z.string(),
+      end: z.string().nullable(),
+      location: z.string(),
+      stack: z.array(z.string()),
+      highlights: z.array(z.string())
+    })
+  ),
+  projects: z.array(projectSchema),
+  blog: z.array(
+    z.object({
+      slug: z.string(),
+      title: z.string(),
+      date: z.string(),
+      tags: z.array(z.string()),
+      excerpt: z.string(),
+      mdx: z.string()
+    })
+  ),
+  contributions: z.object({
+    year: z.number(),
+    heatmap: z.array(
+      z.object({
+        date: z.string(),
+        count: z.number()
+      })
+    )
+  })
+});
+
+export type SiteData = z.infer<typeof dataSchema>;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "melli-portfolio",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint .",
+    "test": "vitest",
+    "e2e": "playwright test",
+    "generate:types": "ts-node scripts/generate-types.ts",
+    "content:validate": "ts-node scripts/validate-content.ts",
+    "prepare": "husky install"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zod": "3.22.4",
+    "tailwindcss": "3.4.1",
+    "lucide-react": "0.381.0",
+    "framer-motion": "11.0.0",
+    "rehype": "13.0.0",
+    "remark": "14.0.0",
+    "recharts": "2.10.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.2",
+    "@types/node": "20.11.0",
+    "@types/react": "18.2.48",
+    "@types/react-dom": "18.2.18",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "prettier": "3.2.5",
+    "vitest": "1.1.3",
+    "@testing-library/react": "14.1.2",
+    "@testing-library/jest-dom": "6.1.4",
+    "playwright": "1.41.1",
+    "husky": "9.0.10",
+    "lint-staged": "15.2.0",
+    "zod-to-ts": "1.2.0",
+    "ts-node": "10.9.2"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,md,mdx,json,css}": ["prettier --write"]
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -1,0 +1,6 @@
+import { writeFileSync } from 'fs';
+import { dataSchema } from '../lib/zod';
+import { zodToTs } from 'zod-to-ts';
+
+const { node } = zodToTs(dataSchema, 'SiteData');
+writeFileSync('lib/generated.d.ts', node); // placeholder

--- a/scripts/validate-content.ts
+++ b/scripts/validate-content.ts
@@ -1,0 +1,9 @@
+import { loadContent } from '../lib/content';
+
+try {
+  loadContent();
+  console.log('Content valid');
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --color-bg: #0d1117;
+}
+
+body {
+  @apply bg-gray-900 text-gray-100;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  darkMode: 'class',
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('home page has pinned projects section', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page.getByText('Pinned Projects')).toBeVisible();
+});

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { loadContent } from '../../lib/content';
+
+describe('content loader', () => {
+  it('loads and validates data.json', () => {
+    const data = loadContent();
+    expect(data.profile.name).toBe('Melli Tiara');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "jest"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js + TypeScript portfolio site
- add JSON-driven content model with Zod validation
- include basic components, pages, Docker, and CI workflows
- remove binary media assets and reference placeholder URLs

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_689d97b2fc44832f9a44b002751ec51a